### PR TITLE
Disable av8::idle on libretro

### DIFF
--- a/avr8.cpp
+++ b/avr8.cpp
@@ -2538,6 +2538,7 @@ void avr8::shutdown(int errcode){
     exit(errcode);
 }
 
+#ifndef __LIBRETRO__
 /* This function is called from GDB while the cpu is stopped */
 void avr8::idle(void){
     SDL_Event event;
@@ -2551,4 +2552,4 @@ void avr8::idle(void){
 
 	usleep(5000);
 }
-
+#endif


### PR DESCRIPTION
It's not used by libretro and needs sleep function