### PR TITLE
Render half-width on 3DS and PSP

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -115,7 +115,7 @@ else ifeq ($(platform), psp1)
 	CC = psp-gcc$(EXE_EXT)
 	CXX = psp-g++$(EXE_EXT)
 	AR = psp-ar$(EXE_EXT)
-	COMMONFLAGS += -DPSP -G0
+	COMMONFLAGS += -DPSP -G0 -I$(shell psp-config --pspsdk-path)/include
 	STATIC_LINKING = 1
 
 # Vita

--- a/uzem_libretro.cpp
+++ b/uzem_libretro.cpp
@@ -219,7 +219,7 @@ bool retro_load_game(const struct retro_game_info *info)
 	};
 
 	// TODO: make this configurable
-#ifdef _PSP
+#if defined (_PSP) || defined (_3DS)
 	half_width = true;
 #else
 	half_width = false;

--- a/uzem_libretro.cpp
+++ b/uzem_libretro.cpp
@@ -46,6 +46,7 @@ extern video_driver_t video_driver_libretro;
 
 static uint32_t *framebuffer = NULL;
 bool done_rendering;
+bool half_width;
 
 static float last_aspect;
 static float last_sample_rate;
@@ -126,10 +127,10 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 	};
 
 	info->geometry = (struct retro_game_geometry){
-		.base_width = 720,
-		.base_height = 448,
-		.max_width = 720,
-		.max_height = 448,
+		.base_width = half_width ? 360 : 720,
+		.base_height = half_width ? 224 : 448,
+		.max_width = half_width ? 360 : 720,
+		.max_height = half_width ? 224 : 448,
 		.aspect_ratio = 630.0/448.0,
 	};
 }
@@ -217,6 +218,13 @@ bool retro_load_game(const struct retro_game_info *info)
 		{ 0},
 	};
 
+	// TODO: make this configurable
+#ifdef _PSP
+	half_width = true;
+#else
+	half_width = false;
+#endif
+
 	environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
 	enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
@@ -278,7 +286,7 @@ bool retro_load_game_special(unsigned type, const struct retro_game_info *info, 
 
 void retro_run(void)
 {
-	unsigned width = 720;
+	unsigned width = half_width ? 360 : 720;
 	unsigned height = 224;
 
 	/* Try rendering straight into VRAM if we can. */

--- a/video_driver_libretro.cpp
+++ b/video_driver_libretro.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "video_driver.h"
 
 extern bool done_rendering;
+extern bool half_width;
 extern video_driver_t video_driver_libretro;
 
 static bool video_driver_libretro_init(const char *caption, bool fullscreen, int sdl_flags)
@@ -43,9 +44,15 @@ static uint32_t video_driver_libretro_map_rgb(uint8_t red, uint8_t green, uint8_
 // Performs a shrink by 2
 static void video_driver_libretro_render_line(unsigned int scanline, uint8_t *src, unsigned int spos, uint32_t *palette)
 {
-	uint32_t *dest = (uint32_t *)((uint8_t *)video_driver_libretro.framebuffer + scanline * video_driver_libretro.stride * 4);
-	for (unsigned int i = 0; i < VIDEO_DISP_WIDTH; i++)
-		dest[i] = palette[src[((i << 1) + spos) & 0x7FFU]];
+	if (half_width) {
+		uint32_t *dest = (uint32_t *)((uint8_t *)video_driver_libretro.framebuffer + scanline * video_driver_libretro.stride * 4);
+		for (unsigned int i = 0; i < VIDEO_DISP_WIDTH / 2; i++)
+			dest[i] = palette[src[((i << 2) + spos) & 0x7FFU]];
+	} else {
+		uint32_t *dest = (uint32_t *)((uint8_t *)video_driver_libretro.framebuffer + scanline * video_driver_libretro.stride * 4);
+		for (unsigned int i = 0; i < VIDEO_DISP_WIDTH; i++)
+			dest[i] = palette[src[((i << 1) + spos) & 0x7FFU]];
+	}
 }
 
 static void video_driver_libretro_update_frame()


### PR DESCRIPTION
PSP scaler is glitchy on widths beyond PSP resolution.
3DS scaler is fine but the low 3DS resolution makes full-resolution rendering pointless anyway
Add missing include for psp